### PR TITLE
fix np.bool error

### DIFF
--- a/umetrics/core.py
+++ b/umetrics/core.py
@@ -340,7 +340,7 @@ class LabeledSegmentation(object):
         self.image = image
 
         # label it
-        self.labeled, self.n_labels = label(image.astype(np.bool))
+        self.labeled, self.n_labels = label(image.astype(bool))
 
     @property
     def shape(self):


### PR DESCRIPTION
Hi Alan, 

I'm using your `umetrics` package to score segmentation accuracy to validate some of my segmentations. Unfortunately it contains the deprecated `np.bool`. I have replaced the once use of `np.bool` with `bool` to avoid the `numpy has no attribute np.bool` error. 

I'm hoping you can approve this fix, 

Best, 

Abigail

Summary:
- Replace `np.bool` with `bool`